### PR TITLE
Startup LED Sequence non-blocking

### DIFF
--- a/src/upytester/content/sd/lib/upyt/utils/__init__.py
+++ b/src/upytester/content/sd/lib/upyt/utils/__init__.py
@@ -4,7 +4,9 @@ __all__ = [
 
     # LEDs
     'led_on',
+    'startup_sequence',
 ]
 
 from .interrupts import external_interrupt
 from .leds import led_on
+from .leds import startup_sequence

--- a/src/upytester/content/sd/lib/upyt/utils/leds.py
+++ b/src/upytester/content/sd/lib/upyt/utils/leds.py
@@ -1,5 +1,5 @@
 import pyb
-
+import uasyncio as asyncio
 
 class _LedOnContext(object):
     def __init__(self, led_index):
@@ -24,3 +24,12 @@ def led_on(*args, **kwargs):
         ...     sleep(0.1)
     """
     return _LedOnContext(*args, **kwargs)
+
+
+async def startup_sequence():
+    """Flash onboard LEDs in sequence indicating successful start."""
+    leds = [pyb.LED(i+1) for i in range(4)]
+    for i in [3, 2, 1, 0, 1, 2, 3]:
+        leds[i].on()
+        await asyncio.sleep_ms(50)
+        leds[i].off()

--- a/src/upytester/content/sd/lib/upyt/utils/leds.py
+++ b/src/upytester/content/sd/lib/upyt/utils/leds.py
@@ -14,7 +14,7 @@ class _LedOnContext(object):
 
 def led_on(*args, **kwargs):
     """
-    Keeps a LED on while in context.
+    Keep a LED on while in context.
 
     For example, the following code will turn the red LED on for 100ms::
 

--- a/src/upytester/content/sd/main.py
+++ b/src/upytester/content/sd/main.py
@@ -9,22 +9,13 @@ import json
 import uasyncio as asyncio
 
 # upytester module(s)
-from upyt.utils import external_interrupt
 from upyt.cmd import interpret, set_serial_port
+from upyt.utils import startup_sequence
 import upyt.sched
 
 
 # Allocate memory for callback debugging
 micropython.alloc_emergency_exception_buf(100)
-
-def _startup_flash():
-    # Flash onboard LEDs in sequence
-    for i in [4, 3, 2, 1, 2, 3, 4]:
-        pyb.LED(i).on()
-        time.sleep(0.05)
-        pyb.LED(i).off()
-
-_startup_flash()
 
 vcp = pyb.USB_VCP()
 set_serial_port(vcp)
@@ -94,7 +85,7 @@ except ImportError as e:
 
 # Main loop
 try:
-    # start asyncio.get_event_loop()
+    upyt.sched.loop.create_task(startup_sequence())
     upyt.sched.loop.run_until_complete(listener())
 except Exception as e:
     with open('/sd/exception.txt', 'w') as fh:

--- a/src/upytester/content/sd/main.py
+++ b/src/upytester/content/sd/main.py
@@ -1,5 +1,4 @@
 import pyb
-import machine
 import sys
 import micropython
 
@@ -20,7 +19,9 @@ micropython.alloc_emergency_exception_buf(100)
 vcp = pyb.USB_VCP()
 set_serial_port(vcp)
 
+
 def process_line(line):
+    """Process received line as a upyt command."""
     # Receive & decode data
     try:
         obj = json.loads(line)
@@ -48,11 +49,9 @@ def process_line(line):
     interpret(obj)
     vcp.write(b'ok\r')
 
+
 async def listener():
-    """
-    Reads lines from Virtual Comm Port (VCP) and send them to be
-    processed.
-    """
+    """Read and process lines from Virtual Comm Port (VCP)."""
     # TODO: create a global buffer, and populate via memoryview
     line = b''
 
@@ -76,7 +75,7 @@ upyt.sched.init_loop()  # initialize asyncio loop object
 sys.path.append('/sd/lib_bench')
 sys.path.append('/flash/lib_bench')
 try:
-    import bench
+    import bench  # noqa: F401
 except ImportError as e:
     if "'bench'" not in e.args[0]:
         # import error was not from a nested library fault


### PR DESCRIPTION
Startup LED sequence as an `async` task so it doesn't delay processing