### PR TITLE
await asynchronous instructions

### DIFF
--- a/examples/02-on-board-components/03-async-function/.upytester-bench.yml
+++ b/examples/02-on-board-components/03-async-function/.upytester-bench.yml
@@ -1,0 +1,3 @@
+bench:
+    libraries:
+        sd: 'bench_lib'

--- a/examples/02-on-board-components/03-async-function/bench_lib/bench.py
+++ b/examples/02-on-board-components/03-async-function/bench_lib/bench.py
@@ -1,0 +1,1 @@
+import blink

--- a/examples/02-on-board-components/03-async-function/bench_lib/blink.py
+++ b/examples/02-on-board-components/03-async-function/bench_lib/blink.py
@@ -1,0 +1,26 @@
+import pyb
+from upyt.cmd import instruction, remote
+import uasyncio as asyncio
+
+
+@instruction('async_blink')
+async def async_blink(led_index: int):
+    led = pyb.LED(led_index)
+    for _ in range(3):
+        led.on()
+        await asyncio.sleep_ms(500)
+        led.off()
+        await asyncio.sleep_ms(500)
+
+
+@remote
+class Foo:
+    def __init__(self, led_index: int):
+        self.led = pyb.LED(led_index)
+
+    async def blink(self):
+        for _ in range(3):
+            self.led.on()
+            await asyncio.sleep_ms(500)
+            self.led.off()
+            await asyncio.sleep_ms(500)

--- a/examples/02-on-board-components/03-async-function/bench_lib/blink.py
+++ b/examples/02-on-board-components/03-async-function/bench_lib/blink.py
@@ -8,19 +8,22 @@ async def async_blink(led_index: int):
     led = pyb.LED(led_index)
     for _ in range(3):
         led.on()
-        await asyncio.sleep_ms(500)
+        await asyncio.sleep_ms(5)
         led.off()
-        await asyncio.sleep_ms(500)
+        await asyncio.sleep_ms(5)
 
 
 @remote
-class Foo:
+class MyLED:
     def __init__(self, led_index: int):
         self.led = pyb.LED(led_index)
 
     async def blink(self):
+        import time
         for _ in range(3):
             self.led.on()
-            await asyncio.sleep_ms(500)
+            #time.sleep_ms(5)
+            await asyncio.sleep_ms(5)
             self.led.off()
-            await asyncio.sleep_ms(500)
+            #time.sleep_ms(5)
+            await asyncio.sleep_ms(5)

--- a/examples/02-on-board-components/03-async-function/runtests.sh
+++ b/examples/02-on-board-components/03-async-function/runtests.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m unittest discover -v

--- a/examples/02-on-board-components/03-async-function/test_async.py
+++ b/examples/02-on-board-components/03-async-function/test_async.py
@@ -1,0 +1,22 @@
+import unittest
+import upytester
+
+
+class ReactionTimeTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.pyb_a = upytester.project.get_device('pyb_a')
+
+    @classmethod
+    def tearDownClass(self):
+        self.pyb_a.close()
+
+    #def test_blink_func(self):
+    #    """Run async function."""
+    #    self.pyb_a.async_blink(1)
+
+    def test_blink_remote(self):
+        """Create object and run async function."""
+        obj = self.pyb_a.Foo(2)
+        obj.blink()

--- a/examples/02-on-board-components/03-async-function/test_async.py
+++ b/examples/02-on-board-components/03-async-function/test_async.py
@@ -1,22 +1,26 @@
 import unittest
 import upytester
 
+# Uncomment for verbose output
+#import logging
+#logging.basicConfig(level=logging.DEBUG)
+
 
 class ReactionTimeTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
         self.pyb_a = upytester.project.get_device('pyb_a')
+        self.led = self.pyb_a.MyLED(2)
 
     @classmethod
     def tearDownClass(self):
         self.pyb_a.close()
 
-    #def test_blink_func(self):
-    #    """Run async function."""
-    #    self.pyb_a.async_blink(1)
+    def test_blink_func(self):
+        """Run async function."""
+        self.pyb_a.async_blink(1)
 
     def test_blink_remote(self):
         """Create object and run async function."""
-        obj = self.pyb_a.Foo(2)
-        obj.blink()
+        self.led.blink()

--- a/src/upytester/content/sd/lib/upyt/cmd/mapping.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/mapping.py
@@ -2,6 +2,7 @@
 import json
 import gc
 
+from .types import type_gen_func, type_func
 
 # -------------- Instructions --------------
 _instruction_map = {}
@@ -37,7 +38,7 @@ def instruction(func):
     Because the method name, and keyword arguments are serialized and
     transmitted, consider keeping argument & method names short.
     """
-    if not isinstance(func, type(lambda: None)):
+    if not isinstance(func, (type_func, type_gen_func)):
         raise ValueError("{!r} is not a method".format(func))
     if func.__name__ in _instruction_map:
         raise ValueError("duplicate instruction; can't replace {old!r} with {new!r}".format(  # noqa: E501

--- a/src/upytester/content/sd/lib/upyt/cmd/mapping.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/mapping.py
@@ -8,7 +8,7 @@ from .types import type_gen_func, type_func
 _instruction_map = {}
 
 
-def instruction(func):
+def instruction(arg):
     r"""
     Map a function to an incoming instruction.
 
@@ -38,14 +38,25 @@ def instruction(func):
     Because the method name, and keyword arguments are serialized and
     transmitted, consider keeping argument & method names short.
     """
-    if not isinstance(func, (type_func, type_gen_func)):
-        raise ValueError("{!r} is not a method".format(func))
-    if func.__name__ in _instruction_map:
-        raise ValueError("duplicate instruction; can't replace {old!r} with {new!r}".format(  # noqa: E501
-            old=_instruction_map[func.__name__], new=func,
-        ))
-    _instruction_map[func.__name__] = func
-    return func
+    if isinstance(arg, str):
+        name = arg
+    else:
+        name = arg.__name__
+
+    def decorator(func):
+        if not isinstance(func, (type_func, type_gen_func)):
+            raise ValueError("{!r} is not a method".format(func))
+        if name in _instruction_map:
+            raise ValueError("duplicate instruction; can't replace {old!r} with {new!r}".format(  # noqa: E501
+                old=_instruction_map[name], new=func,
+            ))
+        _instruction_map[name] = func
+        return func
+
+    if isinstance(arg, str):
+        return decorator
+    else:
+        return decorator(arg)
 
 
 @instruction

--- a/src/upytester/content/sd/lib/upyt/cmd/process.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/process.py
@@ -3,8 +3,12 @@ import json
 
 from . import mapping
 
+# ref: https://forum.micropython.org/viewtopic.php?t=5538
+TYPE_GEN = type((lambda: (yield))())  # Generator type
+TYPE_GEN_FUNC = type((lambda: (yield)))  # Generator function
 
-def interpret_instruction(obj: dict):
+
+async def interpret_instruction(obj: dict):
     """
     Interpret obj as arguments for the named instruction.
 
@@ -30,9 +34,12 @@ def interpret_instruction(obj: dict):
     if instruction_name not in mapping._instruction_map:
         return
 
-    # Execute function
+    # Execute (async / non-async)
     func = mapping._instruction_map[instruction_name]
-    response = func(*obj.get('a', []), **obj.get('k', {}))
+    if isinstance(func, TYPE_GEN_FUNC):  # assumed async
+        response = await func(*obj.get('a', []), **obj.get('k', {}))
+    else:
+        response = func(*obj.get('a', []), **obj.get('k', {}))
 
     # Send response (if any given)
     if response is not None:
@@ -80,7 +87,7 @@ def interpret_new_remote_instance(obj: dict):
     mapping.send(instance._upyt_id)
 
 
-def interpret_remote_instruction(obj: dict):
+async def interpret_remote_instruction(obj: dict):
     """
     Interpret obj as a function call to an existing remote class instance.
 
@@ -105,36 +112,45 @@ def interpret_remote_instruction(obj: dict):
     """
     # Fetch remote instance from ID
     instance = mapping._remote_instance_map[obj.get('rid')]
-    attr = getattr(instance, obj.get('i'))
-    if not callable(attr):
+
+    # Get function as attribute of instance
+    func = getattr(instance, obj.get('i'))
+    if not callable(func):
         raise AttributeError("non-callable attributes are not supported")
-    response = attr(*obj.get('a', []), **obj.get('k', {}))
+
+    # Execute (async / non-async)
+    if isinstance(func, TYPE_GEN_FUNC):  # assumed async
+        response = await func(*obj.get('a', []), **obj.get('k', {}))
+    else:
+        response = func(*obj.get('a', []), **obj.get('k', {}))
 
     # Send response (if any given)
     if response is not None:
         mapping.send(response)
 
 
-def interpret(obj):
+async def interpret(obj):
     """
     Perform the action defined in the given object.
 
     :param obj: deserialized JSON object received from host
     :type obj: :class:`dict`
 
-    Given ``obj`` must be accepted by either :meth:`interpret_instruction`
-    or :meth:`interpret_new_remote_instance`.
+    Given ``obj`` must be accepted by either
+    :meth:`interpret_instruction`,
+    :meth:`interpret_new_remote_instance`, or
+    :meth:`interpret_remote_instruction`.
     """
     # Find referenced function
     if not isinstance(obj, dict):
         return
 
     if 'rid' in obj:
-        interpret_remote_instruction(obj)
+        await interpret_remote_instruction(obj)
     elif 'rc' in obj:
         interpret_new_remote_instance(obj)
     elif 'i' in obj:
-        interpret_instruction(obj)
+        await interpret_instruction(obj)
     else:
         pass  # ignore instruction
 
@@ -159,7 +175,7 @@ async def listener(stream):
                 #       to complete before the host can begin to process the next command.
                 #       However, it does enable tests to... you know... fail when they
                 #       should. So the choice seems like a no-brainer.
-                interpret(json.loads(line))
+                await interpret(json.loads(line))
                 stream.write(b'ok\r')
                 # Clear line
                 line = b''

--- a/src/upytester/content/sd/lib/upyt/cmd/process.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/process.py
@@ -2,7 +2,7 @@ import uasyncio as asyncio
 import json
 
 from . import mapping
-from .types import type_gen_func
+from .types import type_coro, type_bound_coro
 
 
 async def interpret_instruction(obj: dict):
@@ -33,10 +33,9 @@ async def interpret_instruction(obj: dict):
 
     # Execute (async / non-async)
     func = mapping._instruction_map[instruction_name]
-    if isinstance(func, type_gen_func):  # assumed async
-        response = await func(*obj.get('a', []), **obj.get('k', {}))
-    else:
-        response = func(*obj.get('a', []), **obj.get('k', {}))
+    response = func(*obj.get('a', []), **obj.get('k', {}))
+    if isinstance(response, type_coro):  # assumed async
+        response = await response
 
     # Send response (if any given)
     if response is not None:
@@ -116,10 +115,9 @@ async def interpret_remote_instruction(obj: dict):
         raise AttributeError("non-callable attributes are not supported")
 
     # Execute (async / non-async)
-    if isinstance(func, type_gen_func):  # assumed async
-        response = await func(*obj.get('a', []), **obj.get('k', {}))
-    else:
-        response = func(*obj.get('a', []), **obj.get('k', {}))
+    response = func(*obj.get('a', []), **obj.get('k', {}))
+    if isinstance(response, type_bound_coro):
+        response = await response
 
     # Send response (if any given)
     if response is not None:

--- a/src/upytester/content/sd/lib/upyt/cmd/process.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/process.py
@@ -2,10 +2,7 @@ import uasyncio as asyncio
 import json
 
 from . import mapping
-
-# ref: https://forum.micropython.org/viewtopic.php?t=5538
-TYPE_GEN = type((lambda: (yield))())  # Generator type
-TYPE_GEN_FUNC = type((lambda: (yield)))  # Generator function
+from .types import type_gen_func
 
 
 async def interpret_instruction(obj: dict):
@@ -36,7 +33,7 @@ async def interpret_instruction(obj: dict):
 
     # Execute (async / non-async)
     func = mapping._instruction_map[instruction_name]
-    if isinstance(func, TYPE_GEN_FUNC):  # assumed async
+    if isinstance(func, type_gen_func):  # assumed async
         response = await func(*obj.get('a', []), **obj.get('k', {}))
     else:
         response = func(*obj.get('a', []), **obj.get('k', {}))
@@ -119,7 +116,7 @@ async def interpret_remote_instruction(obj: dict):
         raise AttributeError("non-callable attributes are not supported")
 
     # Execute (async / non-async)
-    if isinstance(func, TYPE_GEN_FUNC):  # assumed async
+    if isinstance(func, type_gen_func):  # assumed async
         response = await func(*obj.get('a', []), **obj.get('k', {}))
     else:
         response = func(*obj.get('a', []), **obj.get('k', {}))

--- a/src/upytester/content/sd/lib/upyt/cmd/types.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/types.py
@@ -2,3 +2,7 @@ type_func = type((lambda: None))
 # ref: https://forum.micropython.org/viewtopic.php?t=5538
 type_gen = type((lambda: (yield))())  # Generator type
 type_gen_func = type((lambda: (yield)))  # Generator function
+
+# Async types
+type_coro = type((lambda: (yield))())
+type_bound_coro = type(type('_', (object,), {'x': lambda s: (yield)})().x())

--- a/src/upytester/content/sd/lib/upyt/cmd/types.py
+++ b/src/upytester/content/sd/lib/upyt/cmd/types.py
@@ -1,0 +1,4 @@
+type_func = type((lambda: None))
+# ref: https://forum.micropython.org/viewtopic.php?t=5538
+type_gen = type((lambda: (yield))())  # Generator type
+type_gen_func = type((lambda: (yield)))  # Generator function

--- a/src/upytester/pyboard/pyboard.py
+++ b/src/upytester/pyboard/pyboard.py
@@ -626,6 +626,13 @@ class PyBoard(object):
             self._pyboard = pyboard
             self._idx = idx
 
+        def __repr__(self):
+            return "<{cls}: @remote[{idx}] on {pyboard!r}>".format(
+                cls=self.__class__.__name__,
+                idx=self._idx,
+                pyboard=self._pyboard,
+            )
+
         def __getattr__(self, key):
             def func(*args, **kwargs):
                 payload = self._pyboard._payload(


### PR DESCRIPTION
An asynchronous function can now be labelled an instruction

**pyboard**
```python
@instruction('foo')
async def foo():
    await asyncio.sleep(0)
    return 'abc'
```

Note: instruction needs to be explicitly named, because coroutines don't have a `__name__`

**Host PC**
```python
>>> pyboard.foo()
'abc'
```